### PR TITLE
Android video fixes

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -225,7 +225,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
         }
 
         cm.fileFormat = MediaRecorder.OutputFormat.MPEG_4;
-        cm.videoCodec = MediaRecorder.VideoEncoder.MPEG_4_SP;
         mMediaRecorder.setProfile(cm);
 
         mVideoFile = null;

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -593,14 +593,12 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
     private File getTempMediaFile(int type) {
         try {
             String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-            File outputDir;
+            File outputDir = _reactContext.getCacheDir();
             File outputFile;
 
             if (type == MEDIA_TYPE_IMAGE) {
-                outputDir = _reactContext.getCacheDir(); // for backwards compatibility
                 outputFile = File.createTempFile("IMG_" + timeStamp, ".jpg", outputDir);
             } else if (type == MEDIA_TYPE_VIDEO) {
-                outputDir = _reactContext.getFilesDir(); // for compatibility with react-native-fs
                 outputFile = File.createTempFile("VID_" + timeStamp, ".mp4", outputDir);
             } else {
                 Log.e(TAG, "Unsupported media type:" + type);


### PR DESCRIPTION
This PR includes fixes for two issues (https://github.com/lwansbrough/react-native-camera/pull/262#discussion_r74119453, https://github.com/lwansbrough/react-native-camera/pull/262#discussion_r74469302).
1. It saves video files to the cache directory correctly when requested by the user.
2. It doesn't specify the recording codec, allowing the system to choose an appropriate one.

I've tested these changes in my project and they appear to work.
