### PR TITLE
Android recording fix

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -180,22 +180,25 @@ public class RCTCamera {
             return null;
         }
 
-        CamcorderProfile cm = CamcorderProfile.get(_cameraTypeToIndex.get(cameraType), CamcorderProfile.QUALITY_HIGH);
-        if (cm == null){
-            return null;
-        }
-
         Camera.Size videoSize = null;
+        CamcorderProfile cm = null;
         switch (captureQuality) {
             case RCTCameraModule.RCT_CAMERA_CAPTURE_QUALITY_LOW:
                 videoSize = getSmallestSize(getSupportedVideoSizes(camera));
+                cm = CamcorderProfile.get(_cameraTypeToIndex.get(cameraType), CamcorderProfile.QUALITY_480P);
                 break;
             case RCTCameraModule.RCT_CAMERA_CAPTURE_QUALITY_MEDIUM:
                 List<Camera.Size> sizes = getSupportedVideoSizes(camera);
                 videoSize = sizes.get(sizes.size() / 2);
+                cm = CamcorderProfile.get(_cameraTypeToIndex.get(cameraType), CamcorderProfile.QUALITY_720P);
                 break;
             case RCTCameraModule.RCT_CAMERA_CAPTURE_QUALITY_HIGH:
                 videoSize = getBestSize(getSupportedVideoSizes(camera), Integer.MAX_VALUE, Integer.MAX_VALUE);
+                cm = CamcorderProfile.get(_cameraTypeToIndex.get(cameraType), CamcorderProfile.QUALITY_HIGH);
+        }
+
+        if (cm == null){
+            return null;
         }
 
         if (videoSize != null) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -6,11 +6,11 @@
 package com.lwansbrough.RCTCamera;
 
 import android.content.ContentValues;
-import android.content.Intent;
 import android.hardware.Camera;
 import android.media.CamcorderProfile;
 import android.media.MediaActionSound;
 import android.media.MediaRecorder;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -364,10 +364,9 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
 
                 values.put(MediaStore.Video.Media.MIME_TYPE, "video/mp4");
                 _reactContext.getContentResolver().insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values);
-                Uri fileUri = Uri.fromFile(mVideoFile);
-                response.putString("path", fileUri.toString());
+                addToMediaStore(mVideoFile.getAbsolutePath());
+                response.putString("path", Uri.fromFile(mVideoFile).toString());
                 mRecordingPromise.resolve(response);
-                addToMediaStore(fileUri);
                 break;
             case RCT_CAMERA_CAPTURE_TARGET_TEMP:
             case RCT_CAMERA_CAPTURE_TARGET_DISK:
@@ -469,10 +468,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
                             return;
                         }
 
-                        Uri fileUri = Uri.fromFile(cameraRollFile);
-                        addToMediaStore(fileUri);
-
-                        response.putString("path", fileUri.toString());
+                        addToMediaStore(cameraRollFile.getAbsolutePath());
+                        response.putString("path", Uri.fromFile(cameraRollFile).toString());
                         promise.resolve(response);
                         break;
                     }
@@ -489,10 +486,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
                             return;
                         }
 
-                        Uri fileUri = Uri.fromFile(pictureFile);
-                        addToMediaStore(fileUri);
-
-                        response.putString("path", fileUri.toString());
+                        addToMediaStore(pictureFile.getAbsolutePath());
+                        response.putString("path", Uri.fromFile(pictureFile).toString());
                         promise.resolve(response);
                         break;
                     }
@@ -611,14 +606,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
         }
     }
 
-    private void addToMediaStore(Uri uri) {
-        if (uri == null) {
-            Log.e(TAG, "Tried to store null url to media store.");
-            return;
-        }
-
-        Intent mediaScannerIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-        mediaScannerIntent.setData(uri);
-        _reactContext.sendBroadcast(mediaScannerIntent);
+    private void addToMediaStore(String path) {
+        MediaScannerConnection.scanFile(_reactContext, new String[] { path }, null, null);
     }
 }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -210,15 +210,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
         mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.CAMCORDER);
         mMediaRecorder.setVideoSource(MediaRecorder.VideoSource.CAMERA);
 
-        int mediaRecorderHintOrientation = (90 + ((720 - RCTCamera.getInstance().getActualDeviceOrientation() * 90))) % 360;
-        // adjust for differences in how devices display front facing http://www.theverge.com/2015/11/9/9696774/google-nexus-5x-upside-down-camera
-        if (RCT_CAMERA_TYPE_FRONT == options.getInt("type")) {
-            if ((RCT_CAMERA_ORIENTATION_PORTRAIT == RCTCamera.getInstance().getOrientation()) && (RCTCamera.getInstance().getAdjustedDeviceOrientation() == 90)) {
-                mediaRecorderHintOrientation += 180;
-            }
-        }
-
-        mMediaRecorder.setOrientationHint(mediaRecorderHintOrientation);
+        mMediaRecorder.setOrientationHint(RCTCamera.getInstance().getAdjustedDeviceOrientation());
 
         if (cm == null) {
             return new RuntimeException("CamcorderProfile not found in prepareMediaRecorder.");


### PR DESCRIPTION
- Using MediaScannerConnection instead of ACTION_MEDIA_SCANNER_SCAN_FILE intent
- As described in https://github.com/lwansbrough/react-native-camera/pull/262#issuecomment-239622268 fixed video the wrong direction and recoder start fail at "low,medium" on the nexus 5 x
